### PR TITLE
Add CORS support for koa routes

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -14,12 +14,14 @@
     "license": "MIT",
     "devDependencies": {
         "@types/koa": "^2.0.46",
-        "@types/node": "^8.10.29",
         "@types/koa-router": "^7.0.32",
+        "@types/koa2-cors": "^2.0.1",
+        "@types/node": "^8.10.36",
         "typescript": "^3.0.3"
     },
     "dependencies": {
         "koa": "^2.5.3",
-        "koa-router": "^7.4.0"
+        "koa-router": "^7.4.0",
+        "koa2-cors": "^2.0.6"
     }
 }

--- a/server/src/monitor.ts
+++ b/server/src/monitor.ts
@@ -1,4 +1,5 @@
 import Koa from 'koa'
+import cors from 'koa2-cors'
 import Router, { IRouterContext } from 'koa-router'
 import { SLPServer } from './udpserver'
 import { join } from 'path'
@@ -25,6 +26,7 @@ export class ServerMonitor {
   }
 
   public start(port: number) {
+    this.app.use(cors())
     this.app.use(this.router.routes())
     this.app.listen(port)
     console.log(`\nMonitor service started on port ${port}/tcp`)


### PR DESCRIPTION
Currently, CORS requests fails in a browser.
So it's tricky to make ajax/fetch request on the /info endpoint.

In this PR, I add a middleware to supports CORS with koa.
