### PR TITLE
fix Mac Mojave can not find libuv bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,16 @@ include_directories(
     lwip/src/include
     src
 )
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    include_directories(
+        /usr/local/Cellar/libuv/1.24.0/include
+    )
+link_directories(
+    /usr/local/Cellar/libuv/1.24.0/lib
+)
+endif()
+
 add_subdirectory(lwip)
 
 if (WIN32)


### PR DESCRIPTION
Hello：

      Switch lan play is so Cool

      I build on mac Mojave 10.14 ,

      can not find libuv , this patch fix it