### PR TITLE
修复了 Mac OS X 编译的错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,15 +138,23 @@ make
 ## Mac OS
 
 ```sh
-brew install cmake libpcap libuv
+brew install cmake  libuv
 ```
 
 ```sh
+
 mkdir build
 cd build
 cmake ..
+/usr/bin/sed -i ""  's/C_INCLUDES.*/& \-L\/usr\/local\/include \-I\/usr\/local\/include/g' ./CMakeFiles/lan-play.dir/flags.make  #to fix error "uv.h"  file not found
 make
+
 ```
+
+
+
+
+
 
 # Server
 


### PR DESCRIPTION
1.  根据 cmake 的结果， Found PCAP: /Library/Developer/CommandLineTools/SDKs/MacOSX10.14.sdk/usr/lib/libpcap.tbd ， 实际上用不到 libpcap (libpcap 与系统有冲突，因此默认 brew 不允许 /usr/local/include 中包含libpcap)

因此 brew install 直接去掉 libpcap 就可以了。除非你修个查找的 ROOT 或者修改 cmakecache.txt

2.修复了  lan-play.h:18:10: fatal error: 'uv.h' file not found。 使用 sed 添加了 C_INCLUDES 来包含默认的 /usr/local/include 。