### PR TITLE
fix: update msbuild action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: true
-    - name: Setup MSBuild.exe
+    - name: Setup msbuild.exe
       uses: microsoft/setup-msbuild@v1.1
     - name: make
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,13 +31,13 @@ jobs:
       with:
         submodules: true
     - name: Setup MSBuild.exe
-      uses: warrenbuckley/Setup-MSBuild@v1
+      uses: microsoft/setup-msbuild@v1.1
     - name: make
       run: |
         mkdir build
         cd build
         cmake ..
-        MSBuild SwitchLanPlay.sln
+        msbuild SwitchLanPlay.sln
 
     - name: upload built files
       uses: actions/upload-artifact@v1


### PR DESCRIPTION
I saw that the last Windows builds of this repository seemed to have been broken.

As stated by [warrenbuckley](https://github.com/warrenbuckley/Setup-MSBuild#status-archived), the currently used MSBuild action here is retired and https://github.com/microsoft/setup-msbuild shall be used.

Therefore, I figured to try and upgrade the action and see what happens.

It apparently fixes the Windows build as seen [here](https://github.com/FullLifeGames/switch-lan-play/actions/runs/1775190500) which I guess is a good outcome!